### PR TITLE
Free image resources after PDF page rendering

### DIFF
--- a/print.py
+++ b/print.py
@@ -79,6 +79,7 @@ class PDFPrintCleaner:
                 )
 
                 pix = None  # 釋放記憶體
+                page = None  # 釋放頁面資源
 
             doc.close()
             self.logger.info(f"成功渲染 {len(rendered_pages)} 頁")
@@ -124,6 +125,11 @@ class PDFPrintCleaner:
                     page_height,
                     preserveAspectRatio=True,
                 )
+
+                # 釋放圖像相關資源
+                img.close()
+                img_buffer.close()
+                page_data["image"] = None
 
                 c.showPage()
 


### PR DESCRIPTION
## Summary
- Release PyMuPDF pixmap and page references after each page render to lower memory usage.
- Close PIL images and in-memory buffers after drawing to the PDF canvas, clearing `page_data['image']`.

## Testing
- `python -m py_compile print.py`
- `python print.py --help` *(fails: No module named 'fitz')*
- `pip install PyMuPDF reportlab Pillow` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6894ad87fa3c8322a20a0b2b263a5dba